### PR TITLE
Max size of test set passed at once + bagging fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ X, y = load_breast_cancer(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
 
 # Initialize a classifier
-clf = ConTextTabClassifier(bagging=1, max_context_size=2048)
+clf = ConTextTabClassifier(bagging=1, max_context_size=2048, test_chunk_size=1000)
 
 clf.fit(X_train, y_train)
 
@@ -75,7 +75,7 @@ y = df.target.astype(float)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
 
 # Initialize the regressor
-regressor = ConTextTabRegressor(bagging=1, max_context_size=2048)
+regressor = ConTextTabRegressor(bagging=1, max_context_size=2048, test_chunk_size=1000)
 
 regressor.fit(X_train, y_train)
 

--- a/contexttab/data/tokenizer.py
+++ b/contexttab/data/tokenizer.py
@@ -309,9 +309,12 @@ class Tokenizer:
 
     def replace_inf_values(self, column_values: pd.Series):
         array_values = column_values.values
-        max_value = array_values[np.isfinite(array_values)].max()
-        min_value = array_values[np.isfinite(array_values)].min()
-        clipped_values = np.clip(array_values, min_value - 1, max_value + 1)
+        if not np.isfinite(array_values).any():
+            clipped_values = np.full(array_values.shape, np.nan)
+        else:
+            max_value = array_values[np.isfinite(array_values)].max()
+            min_value = array_values[np.isfinite(array_values)].min()
+            clipped_values = np.clip(array_values, min_value - 1, max_value + 1)
         return pd.Series(clipped_values, index=column_values.index)
 
     def process_features(self, X_context, X_query, data):

--- a/contexttab/model/torch_model.py
+++ b/contexttab/model/torch_model.py
@@ -283,6 +283,8 @@ class ConTextTab(nn.Module, ModuleUtilsMixin):
                     out = torch.sigmoid(out)
                 if self.classification_type in ['clustering', 'clustering-cosine']:
                     out = (out + out.transpose(-2, -1)) / 2
+                if self.regression_type == 'l2':
+                    out = out.squeeze(-1)
             return out
 
         assert target is not None


### PR DESCRIPTION
I received an email from colleagues from the SAP CTO R&I team based in Palo Alto that they tried to run our ConTextTab model on the SALT dataset and A100 GPU runs out of memory for them. That is because they were passing the entire test set at once to the predict method instead of chunking it. I have added the fix to automatically chunk the test set and pass max 1000 test rows in each inference call, that is also configurable. It is a matter of time until somebody else complains with the same error, so better that we chunk it for them.

I moved some of the other small changes like we skip bagging for the dataset that is smaller than max_context_size. That was tested to give better scores on open-source evaluation benchmarks.

Btw, they were running our model on the below dataset. Their code to get the SALT table:
```
def get_dataset(column_to_predict):
    dataset_name = "sap-ai-research/SALT"
    df_train = load_dataset(dataset_name, "joined_table", split='train').to_pandas()
    df_test = load_dataset(dataset_name, "joined_table", split='test').to_pandas()

    column_to_predict = "PLANT"

    # Remove all invalid rows where column_to_predict is NaN, inf, -inf or empty string
    df_train = df_train[df_train[column_to_predict].notna()]
    df_train = df_train[df_train[column_to_predict] != '']
    df_train = df_train[df_train[column_to_predict] != float('inf')]
    df_train = df_train[df_train[column_to_predict] != float('-inf')]

    df_test = df_test[df_test[column_to_predict].notna()]
    df_test = df_test[df_test[column_to_predict] != '']
    df_test = df_test[df_test[column_to_predict] != float('inf')]
    df_test = df_test[df_test[column_to_predict] != float('-inf')]

    return df_train, df_test
```
