### PR TITLE
Change HF repo due to migration

### DIFF
--- a/contexttab/contexttab.py
+++ b/contexttab/contexttab.py
@@ -77,7 +77,7 @@ class ConTextTabEstimator(BaseEstimator, ABC):
 
         self.model_size = ModelSize[checkpoint.split('/')[-1].split('.')[0]]
         self.checkpoint_revision = checkpoint_revision
-        self.checkpoint = hf_hub_download(repo_id="sap-ai-research/contexttab", filename=checkpoint, revision=checkpoint_revision)
+        self.checkpoint = hf_hub_download(repo_id="SAP/contexttab", filename=checkpoint, revision=checkpoint_revision)
         self.bagging = bagging
         if not isinstance(bagging, int) and bagging != 'auto':
             raise ValueError('bagging must be an integer or "auto"')


### PR DESCRIPTION
Update checkpoint URL. On HuggingFace, `sap-ai-research` repo has migrated to `SAP`.

The old link should still work, however it's a tad cleaner to update it.